### PR TITLE
support control the SNI

### DIFF
--- a/rhttp/README.md
+++ b/rhttp/README.md
@@ -435,6 +435,21 @@ await Rhttp.get(
 );
 ```
 
+### ➤ TLS SNI
+
+Controls the use of TLS server name indication.
+
+```dart
+await Rhttp.get(
+  'https://example.com',
+  settings: const ClientSettings(
+    tlsSettings: TlsSettings(
+      enableTlsSni: false,
+    ),
+  ),
+);
+```
+
 ### ➤ Certificate Pinning
 
 To improve security, you can specify the expected server certificate.

--- a/rhttp/lib/src/model/settings.dart
+++ b/rhttp/lib/src/model/settings.dart
@@ -214,6 +214,9 @@ class TlsSettings {
   /// The maximum TLS version to use.
   final rust_client.TlsVersion? maxTlsVersion;
 
+  /// Enable TLS Server Name Indication (SNI).
+  final bool enableTlsSni;
+
   const TlsSettings({
     this.trustRootCertificates = true,
     this.trustedRootCertificates = const [],
@@ -221,6 +224,7 @@ class TlsSettings {
     this.clientCertificate,
     this.minTlsVersion,
     this.maxTlsVersion,
+    this.enableTlsSni = true,
   });
 }
 
@@ -394,6 +398,7 @@ extension on TlsSettings {
       clientCertificate: clientCertificate?._toRustType(),
       minTlsVersion: minTlsVersion,
       maxTlsVersion: maxTlsVersion,
+      enableTlsSni: enableTlsSni
     );
   }
 }

--- a/rhttp/lib/src/rust/api/client.dart
+++ b/rhttp/lib/src/rust/api/client.dart
@@ -202,6 +202,7 @@ class TlsSettings {
   final ClientCertificate? clientCertificate;
   final TlsVersion? minTlsVersion;
   final TlsVersion? maxTlsVersion;
+  final bool enableTlsSni;
 
   const TlsSettings({
     required this.trustRootCertificates,
@@ -210,6 +211,7 @@ class TlsSettings {
     this.clientCertificate,
     this.minTlsVersion,
     this.maxTlsVersion,
+    required this.enableTlsSni,
   });
 
   @override
@@ -219,7 +221,8 @@ class TlsSettings {
       verifyCertificates.hashCode ^
       clientCertificate.hashCode ^
       minTlsVersion.hashCode ^
-      maxTlsVersion.hashCode;
+      maxTlsVersion.hashCode ^
+      enableTlsSni.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -231,7 +234,8 @@ class TlsSettings {
           verifyCertificates == other.verifyCertificates &&
           clientCertificate == other.clientCertificate &&
           minTlsVersion == other.minTlsVersion &&
-          maxTlsVersion == other.maxTlsVersion;
+          maxTlsVersion == other.maxTlsVersion &&
+          enableTlsSni == other.enableTlsSni;
 }
 
 enum TlsVersion {

--- a/rhttp/lib/src/rust/frb_generated.dart
+++ b/rhttp/lib/src/rust/frb_generated.dart
@@ -1627,8 +1627,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TlsSettings dco_decode_tls_settings(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 6)
-      throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
+    if (arr.length != 7)
+      throw Exception('unexpected arr length: expect 7 but see ${arr.length}');
     return TlsSettings(
       trustRootCertificates: dco_decode_bool(arr[0]),
       trustedRootCertificates: dco_decode_list_list_prim_u_8_strict(arr[1]),
@@ -1636,6 +1636,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       clientCertificate: dco_decode_opt_box_autoadd_client_certificate(arr[3]),
       minTlsVersion: dco_decode_opt_box_autoadd_tls_version(arr[4]),
       maxTlsVersion: dco_decode_opt_box_autoadd_tls_version(arr[5]),
+      enableTlsSni: dco_decode_bool(arr[6]),
     );
   }
 
@@ -2590,13 +2591,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_decode_opt_box_autoadd_tls_version(deserializer);
     var var_maxTlsVersion =
         sse_decode_opt_box_autoadd_tls_version(deserializer);
+    var var_enableTlsSni = sse_decode_bool(deserializer);
     return TlsSettings(
         trustRootCertificates: var_trustRootCertificates,
         trustedRootCertificates: var_trustedRootCertificates,
         verifyCertificates: var_verifyCertificates,
         clientCertificate: var_clientCertificate,
         minTlsVersion: var_minTlsVersion,
-        maxTlsVersion: var_maxTlsVersion);
+        maxTlsVersion: var_maxTlsVersion,
+        enableTlsSni: var_enableTlsSni);
   }
 
   @protected
@@ -3026,6 +3029,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       case HttpBody_Multipart(field0: final field0):
         sse_encode_i_32(4, serializer);
         sse_encode_box_autoadd_multipart_payload(field0, serializer);
+      default:
+        throw UnimplementedError('');
     }
   }
 
@@ -3046,6 +3051,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       case HttpHeaders_List(field0: final field0):
         sse_encode_i_32(1, serializer);
         sse_encode_list_record_string_string(field0, serializer);
+      default:
+        throw UnimplementedError('');
     }
   }
 
@@ -3077,6 +3084,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_list_prim_u_8_strict(field0, serializer);
       case HttpResponseBody_Stream():
         sse_encode_i_32(2, serializer);
+      default:
+        throw UnimplementedError('');
     }
   }
 
@@ -3216,6 +3225,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       case MultipartValue_File(field0: final field0):
         sse_encode_i_32(2, serializer);
         sse_encode_String(field0, serializer);
+      default:
+        throw UnimplementedError('');
     }
   }
 
@@ -3405,6 +3416,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       case ProxySettings_CustomProxyList(field0: final field0):
         sse_encode_i_32(1, serializer);
         sse_encode_list_custom_proxy(field0, serializer);
+      default:
+        throw UnimplementedError('');
     }
   }
 
@@ -3454,6 +3467,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       case RedirectSettings_LimitedRedirects(field0: final field0):
         sse_encode_i_32(1, serializer);
         sse_encode_i_32(field0, serializer);
+      default:
+        throw UnimplementedError('');
     }
   }
 
@@ -3485,6 +3500,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       case RhttpError_RhttpUnknownError(field0: final field0):
         sse_encode_i_32(6, serializer);
         sse_encode_String(field0, serializer);
+      default:
+        throw UnimplementedError('');
     }
   }
 
@@ -3518,6 +3535,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         self.clientCertificate, serializer);
     sse_encode_opt_box_autoadd_tls_version(self.minTlsVersion, serializer);
     sse_encode_opt_box_autoadd_tls_version(self.maxTlsVersion, serializer);
+    sse_encode_bool(self.enableTlsSni, serializer);
   }
 
   @protected

--- a/rhttp/rust/src/api/client.rs
+++ b/rhttp/rust/src/api/client.rs
@@ -56,6 +56,7 @@ pub struct TlsSettings {
     pub client_certificate: Option<ClientCertificate>,
     pub min_tls_version: Option<TlsVersion>,
     pub max_tls_version: Option<TlsVersion>,
+    pub enable_tls_sni: bool
 }
 
 pub enum DnsSettings {
@@ -229,6 +230,8 @@ fn create_client(settings: ClientSettings) -> Result<RequestClient, RhttpError> 
                     TlsVersion::Tls1_3 => tls::Version::TLS_1_3,
                 });
             }
+
+            client = client.tls_sni(tls_settings.enable_tls_sni);
         }
 
         client = match settings.http_version_pref {

--- a/rhttp/rust/src/frb_generated.rs
+++ b/rhttp/rust/src/frb_generated.rs
@@ -1586,6 +1586,7 @@ impl SseDecode for crate::api::client::TlsSettings {
             <Option<crate::api::client::TlsVersion>>::sse_decode(deserializer);
         let mut var_maxTlsVersion =
             <Option<crate::api::client::TlsVersion>>::sse_decode(deserializer);
+        let mut var_enableTlsSni = <bool>::sse_decode(deserializer);
         return crate::api::client::TlsSettings {
             trust_root_certificates: var_trustRootCertificates,
             trusted_root_certificates: var_trustedRootCertificates,
@@ -1593,6 +1594,7 @@ impl SseDecode for crate::api::client::TlsSettings {
             client_certificate: var_clientCertificate,
             min_tls_version: var_minTlsVersion,
             max_tls_version: var_maxTlsVersion,
+            enable_tls_sni: var_enableTlsSni,
         };
     }
 }
@@ -1869,6 +1871,9 @@ impl flutter_rust_bridge::IntoDart for crate::api::http::HttpBody {
             crate::api::http::HttpBody::Multipart(field0) => {
                 [4.into_dart(), field0.into_into_dart().into_dart()].into_dart()
             }
+            _ => {
+                unimplemented!("");
+            }
         }
     }
 }
@@ -1908,6 +1913,9 @@ impl flutter_rust_bridge::IntoDart for crate::api::http::HttpHeaders {
             }
             crate::api::http::HttpHeaders::List(field0) => {
                 [1.into_dart(), field0.into_into_dart().into_dart()].into_dart()
+            }
+            _ => {
+                unimplemented!("");
             }
         }
     }
@@ -1979,6 +1987,9 @@ impl flutter_rust_bridge::IntoDart for crate::api::http::HttpResponseBody {
                 [1.into_dart(), field0.into_into_dart().into_dart()].into_dart()
             }
             crate::api::http::HttpResponseBody::Stream => [2.into_dart()].into_dart(),
+            _ => {
+                unimplemented!("");
+            }
         }
     }
 }
@@ -2091,6 +2102,9 @@ impl flutter_rust_bridge::IntoDart for crate::api::http::MultipartValue {
             crate::api::http::MultipartValue::File(field0) => {
                 [2.into_dart(), field0.into_into_dart().into_dart()].into_dart()
             }
+            _ => {
+                unimplemented!("");
+            }
         }
     }
 }
@@ -2135,6 +2149,9 @@ impl flutter_rust_bridge::IntoDart for crate::api::client::ProxySettings {
             crate::api::client::ProxySettings::CustomProxyList(field0) => {
                 [1.into_dart(), field0.into_into_dart().into_dart()].into_dart()
             }
+            _ => {
+                unimplemented!("");
+            }
         }
     }
 }
@@ -2156,6 +2173,9 @@ impl flutter_rust_bridge::IntoDart for crate::api::client::RedirectSettings {
             crate::api::client::RedirectSettings::NoRedirect => [0.into_dart()].into_dart(),
             crate::api::client::RedirectSettings::LimitedRedirects(field0) => {
                 [1.into_dart(), field0.into_into_dart().into_dart()].into_dart()
+            }
+            _ => {
+                unimplemented!("");
             }
         }
     }
@@ -2193,6 +2213,9 @@ impl flutter_rust_bridge::IntoDart for crate::api::error::RhttpError {
             }
             crate::api::error::RhttpError::RhttpUnknownError(field0) => {
                 [6.into_dart(), field0.into_into_dart().into_dart()].into_dart()
+            }
+            _ => {
+                unimplemented!("");
             }
         }
     }
@@ -2259,6 +2282,7 @@ impl flutter_rust_bridge::IntoDart for crate::api::client::TlsSettings {
             self.client_certificate.into_into_dart().into_dart(),
             self.min_tls_version.into_into_dart().into_dart(),
             self.max_tls_version.into_into_dart().into_dart(),
+            self.enable_tls_sni.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -2518,6 +2542,9 @@ impl SseEncode for crate::api::http::HttpBody {
                 <i32>::sse_encode(4, serializer);
                 <crate::api::http::MultipartPayload>::sse_encode(field0, serializer);
             }
+            _ => {
+                unimplemented!("");
+            }
         }
     }
 }
@@ -2549,6 +2576,9 @@ impl SseEncode for crate::api::http::HttpHeaders {
             crate::api::http::HttpHeaders::List(field0) => {
                 <i32>::sse_encode(1, serializer);
                 <Vec<(String, String)>>::sse_encode(field0, serializer);
+            }
+            _ => {
+                unimplemented!("");
             }
         }
     }
@@ -2601,6 +2631,9 @@ impl SseEncode for crate::api::http::HttpResponseBody {
             }
             crate::api::http::HttpResponseBody::Stream => {
                 <i32>::sse_encode(2, serializer);
+            }
+            _ => {
+                unimplemented!("");
             }
         }
     }
@@ -2770,6 +2803,9 @@ impl SseEncode for crate::api::http::MultipartValue {
             crate::api::http::MultipartValue::File(field0) => {
                 <i32>::sse_encode(2, serializer);
                 <String>::sse_encode(field0, serializer);
+            }
+            _ => {
+                unimplemented!("");
             }
         }
     }
@@ -2953,6 +2989,9 @@ impl SseEncode for crate::api::client::ProxySettings {
                 <i32>::sse_encode(1, serializer);
                 <Vec<crate::api::client::CustomProxy>>::sse_encode(field0, serializer);
             }
+            _ => {
+                unimplemented!("");
+            }
         }
     }
 }
@@ -3000,6 +3039,9 @@ impl SseEncode for crate::api::client::RedirectSettings {
                 <i32>::sse_encode(1, serializer);
                 <i32>::sse_encode(field0, serializer);
             }
+            _ => {
+                unimplemented!("");
+            }
         }
     }
 }
@@ -3035,6 +3077,9 @@ impl SseEncode for crate::api::error::RhttpError {
                 <i32>::sse_encode(6, serializer);
                 <String>::sse_encode(field0, serializer);
             }
+            _ => {
+                unimplemented!("");
+            }
         }
     }
 }
@@ -3069,6 +3114,7 @@ impl SseEncode for crate::api::client::TlsSettings {
         );
         <Option<crate::api::client::TlsVersion>>::sse_encode(self.min_tls_version, serializer);
         <Option<crate::api::client::TlsVersion>>::sse_encode(self.max_tls_version, serializer);
+        <bool>::sse_encode(self.enable_tls_sni, serializer);
     }
 }
 


### PR DESCRIPTION
add support to disable the tls sni
```dart
await Rhttp.get(
  'https://example.com',
  settings: const ClientSettings(
    tlsSettings: TlsSettings(
      enableTlsSni: false, // defaults to true
    ),
  ),
);
```