### PR TITLE
feat: enable socks proxy support

### DIFF
--- a/rhttp/rust/Cargo.toml
+++ b/rhttp/rust/Cargo.toml
@@ -24,6 +24,7 @@ features = [
     "rustls-tls-native-roots",
     "stream",
     "multipart",
+    "socks",
 
     # Compression
     "brotli",


### PR DESCRIPTION
Allow to use a socks proxy by enabling the "socks" feature of reqwest.