### PR TITLE
Fix the error where the symbol link cannot be correctly parsed when moving the flutter cache to another location using symbol links

### DIFF
--- a/rhttp/cargokit/cmake/resolve_symlinks.ps1
+++ b/rhttp/cargokit/cmake/resolve_symlinks.ps1
@@ -6,15 +6,29 @@ function Resolve-Symlinks {
         [string] $Path
     )
 
-    $Private:Item = Get-Item -LiteralPath $Path
-    if ([string]::IsNullOrEmpty($Private:Item.Target)) {
-        $Private:Parent = Resolve-Symlinks $Private:Item.Parent
-        return Join-Path $Private:Parent $Private:Item.Name
+    [string] $separator = '/'
+    [string[]] $parts = $Path.Split($separator)
+
+    [string] $realPath = ''
+    foreach ($part in $parts) {
+        if ($realPath -and !$realPath.EndsWith($separator)) {
+            $realPath += $separator
+        }
+
+        $realPath += $part.Replace('\', '/')
+
+        # The slash is important when using Get-Item on Drive letters in pwsh.
+        if (-not($realPath.Contains($separator)) -and $realPath.EndsWith(':')) {
+            $realPath += '/'
+        }
+
+        $item = Get-Item $realPath
+        if ($item.LinkTarget) {
+            $realPath = $item.LinkTarget.Replace('\', '/')
+        }
     }
-    else {
-        return $Private:Item.Target
-    }
+    $realPath
 }
 
-$path=Resolve-Symlinks -Path $args[0]
+$path = Resolve-Symlinks -Path $args[0]
 Write-Host $path


### PR DESCRIPTION
Fix the error where the symbol link cannot be correctly parsed when moving the flutter cache to another location using symbol links