### PR TITLE
Support custom http method.

### DIFF
--- a/rhttp/lib/src/client/io/io_request.dart
+++ b/rhttp/lib/src/client/io/io_request.dart
@@ -43,18 +43,7 @@ class RhttpIoRequest implements HttpClientRequest {
     started = true;
 
     final response = client.requestStream(
-      method: switch (method) {
-        'GET' => HttpMethod.get,
-        'POST' => HttpMethod.post,
-        'PUT' => HttpMethod.put,
-        'PATCH' => HttpMethod.patch,
-        'DELETE' => HttpMethod.delete,
-        'HEAD' => HttpMethod.head,
-        'OPTIONS' => HttpMethod.options,
-        'TRACE' => HttpMethod.trace,
-        'CONNECT' => HttpMethod.connect,
-        _ => throw ArgumentError('Unsupported method: $method'),
-      },
+      method: HttpMethod(method.toUpperCase()),
       url: '${uri.scheme}://${uri.host}:${uri.port}${uri.path}',
       headers: HttpHeaders.list([
         for (final entry in headers.headers.entries)

--- a/rhttp/lib/src/dev_tools.dart
+++ b/rhttp/lib/src/dev_tools.dart
@@ -14,7 +14,7 @@ HttpClientRequestProfile? createDevToolsProfile({
 }) {
   final profile = HttpClientRequestProfile.profile(
     requestStartTime: DateTime.now(),
-    requestMethod: request.method.name.toUpperCase(),
+    requestMethod: request.method.value,
     requestUri: switch (request.query?.isNotEmpty ?? false) {
       true => Uri.parse(url).replace(queryParameters: request.query).toString(),
       false => url,

--- a/rhttp/lib/src/model/request.dart
+++ b/rhttp/lib/src/model/request.dart
@@ -187,17 +187,28 @@ enum HttpExpectBody {
 }
 
 /// The HTTP method to use.
-enum HttpMethod {
-  options,
-  get,
-  post,
-  put,
-  delete,
-  head,
-  trace,
-  connect,
-  patch,
-  ;
+class HttpMethod {
+  final String value;
+
+  const HttpMethod(this.value);
+
+  static const options = HttpMethod('OPTIONS');
+
+  static const get = HttpMethod('GET');
+
+  static const post = HttpMethod('POST');
+
+  static const put = HttpMethod('PUT');
+
+  static const delete = HttpMethod('DELETE');
+
+  static const head = HttpMethod('HEAD');
+
+  static const trace = HttpMethod('TRACE');
+
+  static const connect = HttpMethod('CONNECT');
+
+  static const patch = HttpMethod('PATCH');
 }
 
 enum HttpVersionPref {

--- a/rhttp/lib/src/request.dart
+++ b/rhttp/lib/src/request.dart
@@ -425,17 +425,7 @@ Future<rust_stream.Dart2RustStreamReceiver> _createDart2RustStream({
 
 extension on HttpMethod {
   rust.HttpMethod _toRustType() {
-    return switch (this) {
-      HttpMethod.options => rust.HttpMethod.options,
-      HttpMethod.get => rust.HttpMethod.get_,
-      HttpMethod.post => rust.HttpMethod.post,
-      HttpMethod.put => rust.HttpMethod.put,
-      HttpMethod.delete => rust.HttpMethod.delete,
-      HttpMethod.head => rust.HttpMethod.head,
-      HttpMethod.trace => rust.HttpMethod.trace,
-      HttpMethod.connect => rust.HttpMethod.connect,
-      HttpMethod.patch => rust.HttpMethod.patch,
-    };
+    return rust.HttpMethod(method: value);
   }
 }
 

--- a/rhttp/lib/src/rust/api/http.dart
+++ b/rhttp/lib/src/rust/api/http.dart
@@ -117,17 +117,22 @@ sealed class HttpHeaders with _$HttpHeaders {
   ) = HttpHeaders_List;
 }
 
-enum HttpMethod {
-  options,
-  get_,
-  post,
-  put,
-  delete,
-  head,
-  trace,
-  connect,
-  patch,
-  ;
+class HttpMethod {
+  final String method;
+
+  const HttpMethod({
+    required this.method,
+  });
+
+  @override
+  int get hashCode => method.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is HttpMethod &&
+          runtimeType == other.runtimeType &&
+          method == other.method;
 }
 
 class HttpResponse {

--- a/rhttp/lib/src/rust/frb_generated.dart
+++ b/rhttp/lib/src/rust/frb_generated.dart
@@ -444,7 +444,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_opt_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRequestClient(
             client, serializer);
         sse_encode_opt_box_autoadd_client_settings(settings, serializer);
-        sse_encode_http_method(method, serializer);
+        sse_encode_box_autoadd_http_method(method, serializer);
         sse_encode_String(url, serializer);
         sse_encode_opt_list_record_string_string(query, serializer);
         sse_encode_opt_box_autoadd_http_headers(headers, serializer);
@@ -519,7 +519,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_opt_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRequestClient(
             client, serializer);
         sse_encode_opt_box_autoadd_client_settings(settings, serializer);
-        sse_encode_http_method(method, serializer);
+        sse_encode_box_autoadd_http_method(method, serializer);
         sse_encode_String(url, serializer);
         sse_encode_opt_list_record_string_string(query, serializer);
         sse_encode_opt_box_autoadd_http_headers(headers, serializer);
@@ -1055,6 +1055,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  HttpMethod dco_decode_box_autoadd_http_method(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_http_method(raw);
+  }
+
+  @protected
   HttpResponseBody dco_decode_box_autoadd_http_response_body(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return dco_decode_http_response_body(raw);
@@ -1198,7 +1204,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   HttpMethod dco_decode_http_method(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return HttpMethod.values[raw as int];
+    final arr = raw as List<dynamic>;
+    if (arr.length != 1)
+      throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+    return HttpMethod(
+      method: dco_decode_String(arr[0]),
+    );
   }
 
   @protected
@@ -1908,6 +1919,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  HttpMethod sse_decode_box_autoadd_http_method(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_http_method(deserializer));
+  }
+
+  @protected
   HttpResponseBody sse_decode_box_autoadd_http_response_body(
       SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
@@ -2057,8 +2074,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   HttpMethod sse_decode_http_method(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
-    var inner = sse_decode_i_32(deserializer);
-    return HttpMethod.values[inner];
+    var var_method = sse_decode_String(deserializer);
+    return HttpMethod(method: var_method);
   }
 
   @protected
@@ -2925,6 +2942,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_box_autoadd_http_method(
+      HttpMethod self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_http_method(self, serializer);
+  }
+
+  @protected
   void sse_encode_box_autoadd_http_response_body(
       HttpResponseBody self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
@@ -3055,7 +3079,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   void sse_encode_http_method(HttpMethod self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_i_32(self.index, serializer);
+    sse_encode_String(self.method, serializer);
   }
 
   @protected

--- a/rhttp/lib/src/rust/frb_generated.io.dart
+++ b/rhttp/lib/src/rust/frb_generated.io.dart
@@ -183,6 +183,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   HttpHeaders dco_decode_box_autoadd_http_headers(dynamic raw);
 
   @protected
+  HttpMethod dco_decode_box_autoadd_http_method(dynamic raw);
+
+  @protected
   HttpResponseBody dco_decode_box_autoadd_http_response_body(dynamic raw);
 
   @protected
@@ -509,6 +512,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   HttpHeaders sse_decode_box_autoadd_http_headers(SseDeserializer deserializer);
+
+  @protected
+  HttpMethod sse_decode_box_autoadd_http_method(SseDeserializer deserializer);
 
   @protected
   HttpResponseBody sse_decode_box_autoadd_http_response_body(
@@ -881,6 +887,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_box_autoadd_http_headers(
       HttpHeaders self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_box_autoadd_http_method(
+      HttpMethod self, SseSerializer serializer);
 
   @protected
   void sse_encode_box_autoadd_http_response_body(

--- a/rhttp/lib/src/rust/frb_generated.web.dart
+++ b/rhttp/lib/src/rust/frb_generated.web.dart
@@ -185,6 +185,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   HttpHeaders dco_decode_box_autoadd_http_headers(dynamic raw);
 
   @protected
+  HttpMethod dco_decode_box_autoadd_http_method(dynamic raw);
+
+  @protected
   HttpResponseBody dco_decode_box_autoadd_http_response_body(dynamic raw);
 
   @protected
@@ -511,6 +514,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   HttpHeaders sse_decode_box_autoadd_http_headers(SseDeserializer deserializer);
+
+  @protected
+  HttpMethod sse_decode_box_autoadd_http_method(SseDeserializer deserializer);
 
   @protected
   HttpResponseBody sse_decode_box_autoadd_http_response_body(
@@ -883,6 +889,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_box_autoadd_http_headers(
       HttpHeaders self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_box_autoadd_http_method(
+      HttpMethod self, SseSerializer serializer);
 
   @protected
   void sse_encode_box_autoadd_http_response_body(

--- a/rhttp/rust/src/api/http.rs
+++ b/rhttp/rust/src/api/http.rs
@@ -13,31 +13,13 @@ use crate::api::error::RhttpError;
 use crate::api::{error, stream};
 use crate::frb_generated::{RustAutoOpaque, StreamSink};
 
-pub enum HttpMethod {
-    Options,
-    Get,
-    Post,
-    Put,
-    Delete,
-    Head,
-    Trace,
-    Connect,
-    Patch,
+pub struct HttpMethod {
+    pub method: String,
 }
 
 impl HttpMethod {
     fn to_method(&self) -> Method {
-        match self {
-            HttpMethod::Options => Method::OPTIONS,
-            HttpMethod::Get => Method::GET,
-            HttpMethod::Post => Method::POST,
-            HttpMethod::Put => Method::PUT,
-            HttpMethod::Delete => Method::DELETE,
-            HttpMethod::Head => Method::HEAD,
-            HttpMethod::Trace => Method::TRACE,
-            HttpMethod::Connect => Method::CONNECT,
-            HttpMethod::Patch => Method::PATCH,
-        }
+        Method::from_bytes(self.method.as_bytes()).unwrap()
     }
 }
 

--- a/rhttp/rust/src/frb_generated.rs
+++ b/rhttp/rust/src/frb_generated.rs
@@ -1001,19 +1001,8 @@ impl SseDecode for crate::api::http::HttpHeaders {
 impl SseDecode for crate::api::http::HttpMethod {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut inner = <i32>::sse_decode(deserializer);
-        return match inner {
-            0 => crate::api::http::HttpMethod::Options,
-            1 => crate::api::http::HttpMethod::Get,
-            2 => crate::api::http::HttpMethod::Post,
-            3 => crate::api::http::HttpMethod::Put,
-            4 => crate::api::http::HttpMethod::Delete,
-            5 => crate::api::http::HttpMethod::Head,
-            6 => crate::api::http::HttpMethod::Trace,
-            7 => crate::api::http::HttpMethod::Connect,
-            8 => crate::api::http::HttpMethod::Patch,
-            _ => unreachable!("Invalid variant for HttpMethod: {}", inner),
-        };
+        let mut var_method = <String>::sse_decode(deserializer);
+        return crate::api::http::HttpMethod { method: var_method };
     }
 }
 
@@ -1931,18 +1920,7 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::http::HttpHeaders>
 // Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::http::HttpMethod {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
-        match self {
-            Self::Options => 0.into_dart(),
-            Self::Get => 1.into_dart(),
-            Self::Post => 2.into_dart(),
-            Self::Put => 3.into_dart(),
-            Self::Delete => 4.into_dart(),
-            Self::Head => 5.into_dart(),
-            Self::Trace => 6.into_dart(),
-            Self::Connect => 7.into_dart(),
-            Self::Patch => 8.into_dart(),
-            _ => unreachable!(),
-        }
+        [self.method.into_into_dart().into_dart()].into_dart()
     }
 }
 impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for crate::api::http::HttpMethod {}
@@ -2587,23 +2565,7 @@ impl SseEncode for crate::api::http::HttpHeaders {
 impl SseEncode for crate::api::http::HttpMethod {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <i32>::sse_encode(
-            match self {
-                crate::api::http::HttpMethod::Options => 0,
-                crate::api::http::HttpMethod::Get => 1,
-                crate::api::http::HttpMethod::Post => 2,
-                crate::api::http::HttpMethod::Put => 3,
-                crate::api::http::HttpMethod::Delete => 4,
-                crate::api::http::HttpMethod::Head => 5,
-                crate::api::http::HttpMethod::Trace => 6,
-                crate::api::http::HttpMethod::Connect => 7,
-                crate::api::http::HttpMethod::Patch => 8,
-                _ => {
-                    unimplemented!("");
-                }
-            },
-            serializer,
-        );
+        <String>::sse_encode(self.method, serializer);
     }
 }
 

--- a/rhttp/test/mocks.dart
+++ b/rhttp/test/mocks.dart
@@ -10,7 +10,7 @@ import 'package:rhttp/src/rust/lib.dart' as rust_lib;
 
 class MockRustLibApi extends Mock implements RustLibApi {
   MockRustLibApi.createAndRegister() {
-    registerFallbackValue(rust_http.HttpMethod.get_);
+    registerFallbackValue(rust_http.HttpMethod(method: "GET"));
     registerFallbackValue(rust_http.HttpExpectBody.text);
     registerFallbackValue(const ClientSettings(
       httpVersionPref: rust_http.HttpVersionPref.http11,


### PR DESCRIPTION
This PR adds support for custom HTTP methods.
Currently, the package only supports a predefined set of standard HTTP methods. However, some protocols, such as WebDAV, use non-standard HTTP methods.