### PR TITLE
add toUpperCase when check for method

### DIFF
--- a/rhttp/lib/src/client/io/io_request.dart
+++ b/rhttp/lib/src/client/io/io_request.dart
@@ -43,7 +43,7 @@ class RhttpIoRequest implements HttpClientRequest {
     started = true;
 
     final response = client.requestStream(
-      method: switch (method) {
+      method: switch (method.toUpperCase()) {
         'GET' => HttpMethod.get,
         'POST' => HttpMethod.post,
         'PUT' => HttpMethod.put,


### PR DESCRIPTION
## WHY
Current if there's request made into http.Client() with method "get", it will throw error.
```
ClientException: Invalid argument(s): Unsupported method: get, uri=...
#0      RhttpCompatibleClient.send (package:rhttp/src/client/compatible_client.dart:70:16)
```

It used to work because in dart-lang, it was later on called with `toUpperCased` https://github.com/dart-lang/sdk/blob/d878cfbf20375befa09f9bf85f0ba2b87b319427/sdk/lib/_http/http_impl.dart#L2323

## WHAT
1. Add `toUpperCase` for method.