### PR TITLE
Internet permission in release mode for Android example

### DIFF
--- a/rhttp/example/android/app/src/main/AndroidManifest.xml
+++ b/rhttp/example/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET"/>
     <application
         android:label="rhttp_example"
         android:name="${applicationName}"


### PR DESCRIPTION
Add the Internet permission to the `AndroidManifest.xml` of the example project so that internet access is available even when running with `flutter run --release`.