### PR TITLE
Allow specifying UserAgent

### DIFF
--- a/rhttp/lib/src/model/settings.dart
+++ b/rhttp/lib/src/model/settings.dart
@@ -14,6 +14,7 @@ const _keepRedirectSettings = RedirectSettings.limited(-9999);
 const _keepTlsSettings = TlsSettings();
 const _keepDnsSettings = DnsSettings.static();
 const _keepTimeoutSettings = TimeoutSettings();
+const _keepUserAgent = '';
 
 class ClientSettings {
   /// Base URL to be prefixed to all requests.
@@ -42,6 +43,11 @@ class ClientSettings {
   /// DNS settings and resolver overrides.
   final DnsSettings? dnsSettings;
 
+  /// The UserAgent of the client.
+  ///
+  /// By default there will be no UserAgent header added.
+  final String? userAgent;
+
   const ClientSettings({
     this.baseUrl,
     this.httpVersionPref = HttpVersionPref.all,
@@ -51,6 +57,7 @@ class ClientSettings {
     this.redirectSettings,
     this.tlsSettings,
     this.dnsSettings,
+    this.userAgent,
   });
 
   ClientSettings copyWith({
@@ -62,6 +69,7 @@ class ClientSettings {
     RedirectSettings? redirectSettings = _keepRedirectSettings,
     TlsSettings? tlsSettings = _keepTlsSettings,
     DnsSettings? dnsSettings = _keepDnsSettings,
+    String? userAgent = _keepUserAgent,
   }) {
     return ClientSettings(
       baseUrl: identical(baseUrl, _keepBaseUrl) ? this.baseUrl : baseUrl,
@@ -82,6 +90,8 @@ class ClientSettings {
       dnsSettings: identical(dnsSettings, _keepDnsSettings)
           ? this.dnsSettings
           : dnsSettings,
+      userAgent:
+          identical(userAgent, _keepUserAgent) ? this.userAgent : userAgent,
     );
   }
 }
@@ -333,6 +343,7 @@ extension ClientSettingsExt on ClientSettings {
       redirectSettings: redirectSettings?._toRustType(),
       tlsSettings: tlsSettings?._toRustType(),
       dnsSettings: dnsSettings?._toRustType(),
+      userAgent: userAgent,
     );
   }
 }

--- a/rhttp/lib/src/rust/api/client.dart
+++ b/rhttp/lib/src/rust/api/client.dart
@@ -57,6 +57,7 @@ class ClientSettings {
   final RedirectSettings? redirectSettings;
   final TlsSettings? tlsSettings;
   final DnsSettings? dnsSettings;
+  final String? userAgent;
 
   const ClientSettings({
     required this.httpVersionPref,
@@ -66,6 +67,7 @@ class ClientSettings {
     this.redirectSettings,
     this.tlsSettings,
     this.dnsSettings,
+    this.userAgent,
   });
 
   static Future<ClientSettings> default_() =>
@@ -79,7 +81,8 @@ class ClientSettings {
       proxySettings.hashCode ^
       redirectSettings.hashCode ^
       tlsSettings.hashCode ^
-      dnsSettings.hashCode;
+      dnsSettings.hashCode ^
+      userAgent.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -92,7 +95,8 @@ class ClientSettings {
           proxySettings == other.proxySettings &&
           redirectSettings == other.redirectSettings &&
           tlsSettings == other.tlsSettings &&
-          dnsSettings == other.dnsSettings;
+          dnsSettings == other.dnsSettings &&
+          userAgent == other.userAgent;
 }
 
 class CustomProxy {

--- a/rhttp/lib/src/rust/frb_generated.dart
+++ b/rhttp/lib/src/rust/frb_generated.dart
@@ -1124,8 +1124,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ClientSettings dco_decode_client_settings(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 7)
-      throw Exception('unexpected arr length: expect 7 but see ${arr.length}');
+    if (arr.length != 8)
+      throw Exception('unexpected arr length: expect 8 but see ${arr.length}');
     return ClientSettings(
       httpVersionPref: dco_decode_http_version_pref(arr[0]),
       timeoutSettings: dco_decode_opt_box_autoadd_timeout_settings(arr[1]),
@@ -1136,6 +1136,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dnsSettings:
           dco_decode_opt_box_autoadd_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDnsSettings(
               arr[6]),
+      userAgent: dco_decode_opt_String(arr[7]),
     );
   }
 
@@ -2004,6 +2005,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_dnsSettings =
         sse_decode_opt_box_autoadd_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDnsSettings(
             deserializer);
+    var var_userAgent = sse_decode_opt_String(deserializer);
     return ClientSettings(
         httpVersionPref: var_httpVersionPref,
         timeoutSettings: var_timeoutSettings,
@@ -2011,7 +2013,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         proxySettings: var_proxySettings,
         redirectSettings: var_redirectSettings,
         tlsSettings: var_tlsSettings,
-        dnsSettings: var_dnsSettings);
+        dnsSettings: var_dnsSettings,
+        userAgent: var_userAgent);
   }
 
   @protected
@@ -3026,6 +3029,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_opt_box_autoadd_tls_settings(self.tlsSettings, serializer);
     sse_encode_opt_box_autoadd_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDnsSettings(
         self.dnsSettings, serializer);
+    sse_encode_opt_String(self.userAgent, serializer);
   }
 
   @protected

--- a/rhttp/rust/src/api/client.rs
+++ b/rhttp/rust/src/api/client.rs
@@ -19,6 +19,7 @@ pub struct ClientSettings {
     pub redirect_settings: Option<RedirectSettings>,
     pub tls_settings: Option<TlsSettings>,
     pub dns_settings: Option<DnsSettings>,
+    pub user_agent: Option<String>,
 }
 
 pub enum ProxySettings {
@@ -94,6 +95,7 @@ impl Default for ClientSettings {
             redirect_settings: None,
             tls_settings: None,
             dns_settings: None,
+            user_agent: None,
         }
     }
 }
@@ -279,6 +281,12 @@ fn create_client(settings: ClientSettings) -> Result<RequestClient, RhttpError> 
                         resolver: settings.resolver,
                     }));
                 }
+            }
+        }
+
+        if let Some(user_agent) = settings.user_agent {
+            if user_agent != String::new() {
+                client = client.user_agent(user_agent);
             }
         }
 

--- a/rhttp/rust/src/frb_generated.rs
+++ b/rhttp/rust/src/frb_generated.rs
@@ -909,6 +909,7 @@ impl SseDecode for crate::api::client::ClientSettings {
         let mut var_tlsSettings =
             <Option<crate::api::client::TlsSettings>>::sse_decode(deserializer);
         let mut var_dnsSettings = <Option<DnsSettings>>::sse_decode(deserializer);
+        let mut var_userAgent = <Option<String>>::sse_decode(deserializer);
         return crate::api::client::ClientSettings {
             http_version_pref: var_httpVersionPref,
             timeout_settings: var_timeoutSettings,
@@ -917,6 +918,7 @@ impl SseDecode for crate::api::client::ClientSettings {
             redirect_settings: var_redirectSettings,
             tls_settings: var_tlsSettings,
             dns_settings: var_dnsSettings,
+            user_agent: var_userAgent,
         };
     }
 }
@@ -1807,6 +1809,7 @@ impl flutter_rust_bridge::IntoDart for crate::api::client::ClientSettings {
             self.redirect_settings.into_into_dart().into_dart(),
             self.tls_settings.into_into_dart().into_dart(),
             self.dns_settings.into_into_dart().into_dart(),
+            self.user_agent.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -2486,6 +2489,7 @@ impl SseEncode for crate::api::client::ClientSettings {
         );
         <Option<crate::api::client::TlsSettings>>::sse_encode(self.tls_settings, serializer);
         <Option<DnsSettings>>::sse_encode(self.dns_settings, serializer);
+        <Option<String>>::sse_encode(self.user_agent, serializer);
     }
 }
 


### PR DESCRIPTION
Allows specifying the [`User-Agent` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent) that the reqwest client should use.
The [`user_agent` method of the `ClientBuilder`](https://docs.rs/reqwest/latest/reqwest/struct.ClientBuilder.html#method.user_agent) is used on the Rust side.