### PR TITLE
feat: basic cookie handling

### DIFF
--- a/rhttp/CHANGELOG.md
+++ b/rhttp/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+- feat: add basic Cookie handling
+
 ## 0.11.0
 
 - feat: `HttpMethod` accepts any string as method name @wgh136 (#57)

--- a/rhttp/README.md
+++ b/rhttp/README.md
@@ -31,6 +31,7 @@ Web is currently not supported.
 - ✅ Certificate pinning
 - ✅ Proxy support
 - ✅ Custom DNS resolution
+- ✅ Cookies
 - ✅ Strong type safety
 - ✅ DevTools support ([Network tab](https://docs.flutter.dev/tools/devtools/network))
 - ✅ Compatible with [dart:io](https://api.dart.dev/stable/dart-io/HttpClient-class.html), [http](https://pub.dev/packages/http), and [dio](https://pub.dev/packages/dio)
@@ -74,6 +75,7 @@ Checkout the benchmark code [here](https://github.com/Tienisto/rhttp/tree/main/b
   - [Proxy](#-proxy)
   - [Redirects](#-redirects)
   - [DNS resolution](#-dns-resolution)
+  - [Cookies](#-cookies)
   - [User-Agent](#-user-agent)
 - [Intercept](#intercept)
   - [Interceptors](#-interceptors)
@@ -646,6 +648,19 @@ final client = await RhttpClient.create(
       },
     ),
   )
+);
+```
+
+### ➤ Cookies
+
+It is possible to optionally activate automatic Cookie handling. This will store Cookies sent by the
+server in an ephemeral Cookie [`Jar`](https://docs.rs/reqwest/latest/reqwest/cookie/struct.Jar.html).
+
+```dart
+final client = await RhttpClient.create(
+  settings: const ClientSettings(
+    cookieSettings: CookieSettings(storeCookies: true),
+  ),
 );
 ```
 

--- a/rhttp/example/lib/cookies.dart
+++ b/rhttp/example/lib/cookies.dart
@@ -1,0 +1,87 @@
+// ignore_for_file: avoid_print
+
+import 'package:flutter/material.dart';
+import 'package:rhttp/rhttp.dart';
+import 'package:rhttp_example/widgets/response_card.dart';
+
+Future<void> main() async {
+  await Rhttp.init();
+  runApp(const MyApp());
+}
+
+class MyApp extends StatefulWidget {
+  const MyApp({super.key});
+
+  @override
+  State<MyApp> createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  HttpResponse? response;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(
+          title: const Text('Test Page'),
+        ),
+        body: Center(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              ElevatedButton(
+                onPressed: () async {
+                  try {
+                    final client = await RhttpClient.create(
+                      settings: const ClientSettings(
+                          cookieSettings: CookieSettings(storeCookies: true)),
+                    );
+
+                    final res = await client.requestText(
+                      method: HttpMethod.get,
+                      url:
+                          'https://httpbin.org/cookies/set?cookie1=value1&cookie2=value2',
+                    );
+
+                    setState(() {
+                      response = res;
+                    });
+                  } catch (e) {
+                    print(e);
+                  }
+                },
+                child: const Text('Store Cookies'),
+              ),
+              ElevatedButton(
+                onPressed: () async {
+                  try {
+                    final client = await RhttpClient.create(
+                      settings: const ClientSettings(
+                          cookieSettings: CookieSettings.none()),
+                    );
+
+                    final res = await client.requestText(
+                      method: HttpMethod.get,
+                      url:
+                          'https://httpbin.org/cookies/set?cookie1=value1&cookie2=value2',
+                    );
+
+                    setState(() {
+                      response = res;
+                    });
+                  } catch (e) {
+                    print(e);
+                  }
+                },
+                child: const Text('Ignore Cookies'),
+              ),
+              if (response != null) ResponseCard(response: response!),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/rhttp/lib/rhttp.dart
+++ b/rhttp/lib/rhttp.dart
@@ -54,6 +54,7 @@ export 'src/model/request.dart'
 export 'src/model/settings.dart'
     show
         ClientSettings,
+        CookieSettings,
         TimeoutSettings,
         ProxySettings,
         CustomProxy,

--- a/rhttp/lib/src/rust/api/client.dart
+++ b/rhttp/lib/src/rust/api/client.dart
@@ -50,6 +50,7 @@ class ClientCertificate {
 }
 
 class ClientSettings {
+  final CookieSettings? cookieSettings;
   final HttpVersionPref httpVersionPref;
   final TimeoutSettings? timeoutSettings;
   final bool throwOnStatusCode;
@@ -60,6 +61,7 @@ class ClientSettings {
   final String? userAgent;
 
   const ClientSettings({
+    this.cookieSettings,
     required this.httpVersionPref,
     this.timeoutSettings,
     required this.throwOnStatusCode,
@@ -75,6 +77,7 @@ class ClientSettings {
 
   @override
   int get hashCode =>
+      cookieSettings.hashCode ^
       httpVersionPref.hashCode ^
       timeoutSettings.hashCode ^
       throwOnStatusCode.hashCode ^
@@ -89,6 +92,7 @@ class ClientSettings {
       identical(this, other) ||
       other is ClientSettings &&
           runtimeType == other.runtimeType &&
+          cookieSettings == other.cookieSettings &&
           httpVersionPref == other.httpVersionPref &&
           timeoutSettings == other.timeoutSettings &&
           throwOnStatusCode == other.throwOnStatusCode &&
@@ -97,6 +101,24 @@ class ClientSettings {
           tlsSettings == other.tlsSettings &&
           dnsSettings == other.dnsSettings &&
           userAgent == other.userAgent;
+}
+
+class CookieSettings {
+  final bool storeCookies;
+
+  const CookieSettings({
+    required this.storeCookies,
+  });
+
+  @override
+  int get hashCode => storeCookies.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CookieSettings &&
+          runtimeType == other.runtimeType &&
+          storeCookies == other.storeCookies;
 }
 
 class CustomProxy {

--- a/rhttp/lib/src/rust/frb_generated.dart
+++ b/rhttp/lib/src/rust/frb_generated.dart
@@ -1044,6 +1044,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  CookieSettings dco_decode_box_autoadd_cookie_settings(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_cookie_settings(raw);
+  }
+
+  @protected
   HttpBody dco_decode_box_autoadd_http_body(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return dco_decode_http_body(raw);
@@ -1125,19 +1131,31 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ClientSettings dco_decode_client_settings(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 8)
-      throw Exception('unexpected arr length: expect 8 but see ${arr.length}');
+    if (arr.length != 9)
+      throw Exception('unexpected arr length: expect 9 but see ${arr.length}');
     return ClientSettings(
-      httpVersionPref: dco_decode_http_version_pref(arr[0]),
-      timeoutSettings: dco_decode_opt_box_autoadd_timeout_settings(arr[1]),
-      throwOnStatusCode: dco_decode_bool(arr[2]),
-      proxySettings: dco_decode_opt_box_autoadd_proxy_settings(arr[3]),
-      redirectSettings: dco_decode_opt_box_autoadd_redirect_settings(arr[4]),
-      tlsSettings: dco_decode_opt_box_autoadd_tls_settings(arr[5]),
+      cookieSettings: dco_decode_opt_box_autoadd_cookie_settings(arr[0]),
+      httpVersionPref: dco_decode_http_version_pref(arr[1]),
+      timeoutSettings: dco_decode_opt_box_autoadd_timeout_settings(arr[2]),
+      throwOnStatusCode: dco_decode_bool(arr[3]),
+      proxySettings: dco_decode_opt_box_autoadd_proxy_settings(arr[4]),
+      redirectSettings: dco_decode_opt_box_autoadd_redirect_settings(arr[5]),
+      tlsSettings: dco_decode_opt_box_autoadd_tls_settings(arr[6]),
       dnsSettings:
           dco_decode_opt_box_autoadd_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDnsSettings(
-              arr[6]),
-      userAgent: dco_decode_opt_String(arr[7]),
+              arr[7]),
+      userAgent: dco_decode_opt_String(arr[8]),
+    );
+  }
+
+  @protected
+  CookieSettings dco_decode_cookie_settings(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 1)
+      throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+    return CookieSettings(
+      storeCookies: dco_decode_bool(arr[0]),
     );
   }
 
@@ -1432,6 +1450,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ClientSettings? dco_decode_opt_box_autoadd_client_settings(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw == null ? null : dco_decode_box_autoadd_client_settings(raw);
+  }
+
+  @protected
+  CookieSettings? dco_decode_opt_box_autoadd_cookie_settings(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw == null ? null : dco_decode_box_autoadd_cookie_settings(raw);
   }
 
   @protected
@@ -1908,6 +1932,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  CookieSettings sse_decode_box_autoadd_cookie_settings(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_cookie_settings(deserializer));
+  }
+
+  @protected
   HttpBody sse_decode_box_autoadd_http_body(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return (sse_decode_http_body(deserializer));
@@ -1994,6 +2025,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   ClientSettings sse_decode_client_settings(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_cookieSettings =
+        sse_decode_opt_box_autoadd_cookie_settings(deserializer);
     var var_httpVersionPref = sse_decode_http_version_pref(deserializer);
     var var_timeoutSettings =
         sse_decode_opt_box_autoadd_timeout_settings(deserializer);
@@ -2008,6 +2041,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             deserializer);
     var var_userAgent = sse_decode_opt_String(deserializer);
     return ClientSettings(
+        cookieSettings: var_cookieSettings,
         httpVersionPref: var_httpVersionPref,
         timeoutSettings: var_timeoutSettings,
         throwOnStatusCode: var_throwOnStatusCode,
@@ -2016,6 +2050,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         tlsSettings: var_tlsSettings,
         dnsSettings: var_dnsSettings,
         userAgent: var_userAgent);
+  }
+
+  @protected
+  CookieSettings sse_decode_cookie_settings(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_storeCookies = sse_decode_bool(deserializer);
+    return CookieSettings(storeCookies: var_storeCookies);
   }
 
   @protected
@@ -2358,6 +2399,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
     if (sse_decode_bool(deserializer)) {
       return (sse_decode_box_autoadd_client_settings(deserializer));
+    } else {
+      return null;
+    }
+  }
+
+  @protected
+  CookieSettings? sse_decode_opt_box_autoadd_cookie_settings(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    if (sse_decode_bool(deserializer)) {
+      return (sse_decode_box_autoadd_cookie_settings(deserializer));
     } else {
       return null;
     }
@@ -2932,6 +2985,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_box_autoadd_cookie_settings(
+      CookieSettings self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_cookie_settings(self, serializer);
+  }
+
+  @protected
   void sse_encode_box_autoadd_http_body(
       HttpBody self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
@@ -3020,6 +3080,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void sse_encode_client_settings(
       ClientSettings self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_opt_box_autoadd_cookie_settings(self.cookieSettings, serializer);
     sse_encode_http_version_pref(self.httpVersionPref, serializer);
     sse_encode_opt_box_autoadd_timeout_settings(
         self.timeoutSettings, serializer);
@@ -3031,6 +3092,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_opt_box_autoadd_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDnsSettings(
         self.dnsSettings, serializer);
     sse_encode_opt_String(self.userAgent, serializer);
+  }
+
+  @protected
+  void sse_encode_cookie_settings(
+      CookieSettings self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_bool(self.storeCookies, serializer);
   }
 
   @protected
@@ -3330,6 +3398,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_bool(self != null, serializer);
     if (self != null) {
       sse_encode_box_autoadd_client_settings(self, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_opt_box_autoadd_cookie_settings(
+      CookieSettings? self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    sse_encode_bool(self != null, serializer);
+    if (self != null) {
+      sse_encode_box_autoadd_cookie_settings(self, serializer);
     }
   }
 

--- a/rhttp/lib/src/rust/frb_generated.io.dart
+++ b/rhttp/lib/src/rust/frb_generated.io.dart
@@ -177,6 +177,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   ClientSettings dco_decode_box_autoadd_client_settings(dynamic raw);
 
   @protected
+  CookieSettings dco_decode_box_autoadd_cookie_settings(dynamic raw);
+
+  @protected
   HttpBody dco_decode_box_autoadd_http_body(dynamic raw);
 
   @protected
@@ -214,6 +217,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ClientSettings dco_decode_client_settings(dynamic raw);
+
+  @protected
+  CookieSettings dco_decode_cookie_settings(dynamic raw);
 
   @protected
   CustomProxy dco_decode_custom_proxy(dynamic raw);
@@ -312,6 +318,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ClientSettings? dco_decode_opt_box_autoadd_client_settings(dynamic raw);
+
+  @protected
+  CookieSettings? dco_decode_opt_box_autoadd_cookie_settings(dynamic raw);
 
   @protected
   HttpBody? dco_decode_opt_box_autoadd_http_body(dynamic raw);
@@ -508,6 +517,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       SseDeserializer deserializer);
 
   @protected
+  CookieSettings sse_decode_box_autoadd_cookie_settings(
+      SseDeserializer deserializer);
+
+  @protected
   HttpBody sse_decode_box_autoadd_http_body(SseDeserializer deserializer);
 
   @protected
@@ -551,6 +564,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ClientSettings sse_decode_client_settings(SseDeserializer deserializer);
+
+  @protected
+  CookieSettings sse_decode_cookie_settings(SseDeserializer deserializer);
 
   @protected
   CustomProxy sse_decode_custom_proxy(SseDeserializer deserializer);
@@ -653,6 +669,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ClientSettings? sse_decode_opt_box_autoadd_client_settings(
+      SseDeserializer deserializer);
+
+  @protected
+  CookieSettings? sse_decode_opt_box_autoadd_cookie_settings(
       SseDeserializer deserializer);
 
   @protected
@@ -881,6 +901,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       ClientSettings self, SseSerializer serializer);
 
   @protected
+  void sse_encode_box_autoadd_cookie_settings(
+      CookieSettings self, SseSerializer serializer);
+
+  @protected
   void sse_encode_box_autoadd_http_body(
       HttpBody self, SseSerializer serializer);
 
@@ -931,6 +955,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_client_settings(
       ClientSettings self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_cookie_settings(
+      CookieSettings self, SseSerializer serializer);
 
   @protected
   void sse_encode_custom_proxy(CustomProxy self, SseSerializer serializer);
@@ -1041,6 +1069,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_opt_box_autoadd_client_settings(
       ClientSettings? self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_opt_box_autoadd_cookie_settings(
+      CookieSettings? self, SseSerializer serializer);
 
   @protected
   void sse_encode_opt_box_autoadd_http_body(

--- a/rhttp/lib/src/rust/frb_generated.web.dart
+++ b/rhttp/lib/src/rust/frb_generated.web.dart
@@ -179,6 +179,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   ClientSettings dco_decode_box_autoadd_client_settings(dynamic raw);
 
   @protected
+  CookieSettings dco_decode_box_autoadd_cookie_settings(dynamic raw);
+
+  @protected
   HttpBody dco_decode_box_autoadd_http_body(dynamic raw);
 
   @protected
@@ -216,6 +219,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ClientSettings dco_decode_client_settings(dynamic raw);
+
+  @protected
+  CookieSettings dco_decode_cookie_settings(dynamic raw);
 
   @protected
   CustomProxy dco_decode_custom_proxy(dynamic raw);
@@ -314,6 +320,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ClientSettings? dco_decode_opt_box_autoadd_client_settings(dynamic raw);
+
+  @protected
+  CookieSettings? dco_decode_opt_box_autoadd_cookie_settings(dynamic raw);
 
   @protected
   HttpBody? dco_decode_opt_box_autoadd_http_body(dynamic raw);
@@ -510,6 +519,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       SseDeserializer deserializer);
 
   @protected
+  CookieSettings sse_decode_box_autoadd_cookie_settings(
+      SseDeserializer deserializer);
+
+  @protected
   HttpBody sse_decode_box_autoadd_http_body(SseDeserializer deserializer);
 
   @protected
@@ -553,6 +566,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ClientSettings sse_decode_client_settings(SseDeserializer deserializer);
+
+  @protected
+  CookieSettings sse_decode_cookie_settings(SseDeserializer deserializer);
 
   @protected
   CustomProxy sse_decode_custom_proxy(SseDeserializer deserializer);
@@ -655,6 +671,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ClientSettings? sse_decode_opt_box_autoadd_client_settings(
+      SseDeserializer deserializer);
+
+  @protected
+  CookieSettings? sse_decode_opt_box_autoadd_cookie_settings(
       SseDeserializer deserializer);
 
   @protected
@@ -883,6 +903,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       ClientSettings self, SseSerializer serializer);
 
   @protected
+  void sse_encode_box_autoadd_cookie_settings(
+      CookieSettings self, SseSerializer serializer);
+
+  @protected
   void sse_encode_box_autoadd_http_body(
       HttpBody self, SseSerializer serializer);
 
@@ -933,6 +957,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_client_settings(
       ClientSettings self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_cookie_settings(
+      CookieSettings self, SseSerializer serializer);
 
   @protected
   void sse_encode_custom_proxy(CustomProxy self, SseSerializer serializer);
@@ -1043,6 +1071,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_opt_box_autoadd_client_settings(
       ClientSettings? self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_opt_box_autoadd_cookie_settings(
+      CookieSettings? self, SseSerializer serializer);
 
   @protected
   void sse_encode_opt_box_autoadd_http_body(

--- a/rhttp/rust/Cargo.lock
+++ b/rhttp/rust/Cargo.lock
@@ -257,6 +257,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eac901828f88a5241ee0600950ab981148a18f2f756900ffba1b125ca6a3ef9"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,6 +341,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,6 +368,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -930,6 +977,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
+name = "litrs"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -996,6 +1049,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-traits"
@@ -1090,6 +1149,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1105,6 +1170,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
+name = "publicsuffix"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
+dependencies = [
+ "idna",
+ "psl-types",
 ]
 
 [[package]]
@@ -1246,6 +1327,8 @@ dependencies = [
  "async-compression",
  "base64",
  "bytes",
+ "cookie",
+ "cookie_store",
  "encoding_rs",
  "futures-channel",
  "futures-core",
@@ -1565,6 +1648,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
  "num_cpus",
+]
+
+[[package]]
+name = "time"
+version = "0.3.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad298b01a40a23aac4580b67e3dbedb7cc8402f3592d7f49469de2ea4aecdd8"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765c97a5b985b7c11d7bc27fa927dc4fe6af3a6dfb021d28deb60d3bf51e76ef"
+
+[[package]]
+name = "time-macros"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8093bc3e81c3bc5f7879de09619d06c9a5a5e45ca44dfeeb7225bae38005c5c"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/rhttp/rust/Cargo.toml
+++ b/rhttp/rust/Cargo.toml
@@ -18,6 +18,7 @@ version = "0.12.12"
 default-features = false
 features = [
     "charset",
+    "cookies",
     "http2",
     "http3",
     "rustls-tls-webpki-roots",

--- a/rhttp/rust/src/api/client.rs
+++ b/rhttp/rust/src/api/client.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 pub use tokio_util::sync::CancellationToken;
 
 pub struct ClientSettings {
+    pub cookie_settings: Option<CookieSettings>,
     pub http_version_pref: HttpVersionPref,
     pub timeout_settings: Option<TimeoutSettings>,
     pub throw_on_status_code: bool,
@@ -20,6 +21,10 @@ pub struct ClientSettings {
     pub tls_settings: Option<TlsSettings>,
     pub dns_settings: Option<DnsSettings>,
     pub user_agent: Option<String>,
+}
+
+pub struct CookieSettings {
+    pub store_cookies: bool,
 }
 
 pub enum ProxySettings {
@@ -88,6 +93,7 @@ pub enum TlsVersion {
 impl Default for ClientSettings {
     fn default() -> Self {
         ClientSettings {
+            cookie_settings: None,
             http_version_pref: HttpVersionPref::All,
             timeout_settings: None,
             throw_on_status_code: true,
@@ -140,6 +146,10 @@ fn create_client(settings: ClientSettings) -> Result<RequestClient, RhttpError> 
                     }
                 }
             }
+        }
+
+        if let Some(cookie_settings) = settings.cookie_settings {
+            client = client.cookie_store(cookie_settings.store_cookies);
         }
 
         if let Some(redirect_settings) = settings.redirect_settings {

--- a/rhttp/rust/src/frb_generated.rs
+++ b/rhttp/rust/src/frb_generated.rs
@@ -898,6 +898,8 @@ impl SseDecode for crate::api::client::ClientCertificate {
 impl SseDecode for crate::api::client::ClientSettings {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_cookieSettings =
+            <Option<crate::api::client::CookieSettings>>::sse_decode(deserializer);
         let mut var_httpVersionPref = <crate::api::http::HttpVersionPref>::sse_decode(deserializer);
         let mut var_timeoutSettings =
             <Option<crate::api::client::TimeoutSettings>>::sse_decode(deserializer);
@@ -911,6 +913,7 @@ impl SseDecode for crate::api::client::ClientSettings {
         let mut var_dnsSettings = <Option<DnsSettings>>::sse_decode(deserializer);
         let mut var_userAgent = <Option<String>>::sse_decode(deserializer);
         return crate::api::client::ClientSettings {
+            cookie_settings: var_cookieSettings,
             http_version_pref: var_httpVersionPref,
             timeout_settings: var_timeoutSettings,
             throw_on_status_code: var_throwOnStatusCode,
@@ -919,6 +922,16 @@ impl SseDecode for crate::api::client::ClientSettings {
             tls_settings: var_tlsSettings,
             dns_settings: var_dnsSettings,
             user_agent: var_userAgent,
+        };
+    }
+}
+
+impl SseDecode for crate::api::client::CookieSettings {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_storeCookies = <bool>::sse_decode(deserializer);
+        return crate::api::client::CookieSettings {
+            store_cookies: var_storeCookies,
         };
     }
 }
@@ -1305,6 +1318,19 @@ impl SseDecode for Option<crate::api::client::ClientSettings> {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         if (<bool>::sse_decode(deserializer)) {
             return Some(<crate::api::client::ClientSettings>::sse_decode(
+                deserializer,
+            ));
+        } else {
+            return None;
+        }
+    }
+}
+
+impl SseDecode for Option<crate::api::client::CookieSettings> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        if (<bool>::sse_decode(deserializer)) {
+            return Some(<crate::api::client::CookieSettings>::sse_decode(
                 deserializer,
             ));
         } else {
@@ -1802,6 +1828,7 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::client::ClientCertificate>
 impl flutter_rust_bridge::IntoDart for crate::api::client::ClientSettings {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
+            self.cookie_settings.into_into_dart().into_dart(),
             self.http_version_pref.into_into_dart().into_dart(),
             self.timeout_settings.into_into_dart().into_dart(),
             self.throw_on_status_code.into_into_dart().into_dart(),
@@ -1822,6 +1849,23 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::client::ClientSettings>
     for crate::api::client::ClientSettings
 {
     fn into_into_dart(self) -> crate::api::client::ClientSettings {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::client::CookieSettings {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [self.store_cookies.into_into_dart().into_dart()].into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::client::CookieSettings
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::client::CookieSettings>
+    for crate::api::client::CookieSettings
+{
+    fn into_into_dart(self) -> crate::api::client::CookieSettings {
         self
     }
 }
@@ -2476,6 +2520,7 @@ impl SseEncode for crate::api::client::ClientCertificate {
 impl SseEncode for crate::api::client::ClientSettings {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <Option<crate::api::client::CookieSettings>>::sse_encode(self.cookie_settings, serializer);
         <crate::api::http::HttpVersionPref>::sse_encode(self.http_version_pref, serializer);
         <Option<crate::api::client::TimeoutSettings>>::sse_encode(
             self.timeout_settings,
@@ -2490,6 +2535,13 @@ impl SseEncode for crate::api::client::ClientSettings {
         <Option<crate::api::client::TlsSettings>>::sse_encode(self.tls_settings, serializer);
         <Option<DnsSettings>>::sse_encode(self.dns_settings, serializer);
         <Option<String>>::sse_encode(self.user_agent, serializer);
+    }
+}
+
+impl SseEncode for crate::api::client::CookieSettings {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.store_cookies, serializer);
     }
 }
 
@@ -2843,6 +2895,16 @@ impl SseEncode for Option<crate::api::client::ClientSettings> {
         <bool>::sse_encode(self.is_some(), serializer);
         if let Some(value) = self {
             <crate::api::client::ClientSettings>::sse_encode(value, serializer);
+        }
+    }
+}
+
+impl SseEncode for Option<crate::api::client::CookieSettings> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.is_some(), serializer);
+        if let Some(value) = self {
+            <crate::api::client::CookieSettings>::sse_encode(value, serializer);
         }
     }
 }


### PR DESCRIPTION
Adds support for basic Cookie handling.

At the moment any [`Set-Cookie`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie) header sent by the server is ignored. With this PR Cookies are now stored for a specific client for the lifetime of the application (see [`ClientBuilder.cookie_store`](https://docs.rs/reqwest/latest/reqwest/struct.ClientBuilder.html#method.cookie_store) and [`Jar`](https://docs.rs/reqwest/latest/reqwest/cookie/struct.Jar.html) for limitations of this approach).

I decided to create a new `CookieSettings` class so that it is still possible to extend the featureset in the future. For example users may want to read out stored Cookies, store them persistently in their application or may want to add custom cookies to the requests.
I did not implement this, because this current PR would suffice my needs and a second crate ([`reqwest_cookie_store`](https://crates.io/crates/reqwest_cookie_store)) would be required for this functionality.

I also checked the impact on the APK size of enabling the `cookies` feature which was around 0.1 MB.

Please let me know what you think.