### PR TITLE
fix: silence unexpected `cfg` confition name warning

### DIFF
--- a/rhttp/rust/Cargo.toml
+++ b/rhttp/rust/Cargo.toml
@@ -31,6 +31,9 @@ features = [
     "gzip",
 ]
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)'] }
+
 [profile.release]
 opt-level = 3
 strip = true


### PR DESCRIPTION
Currently when compiling the crate, four warnings like the one below appear when using Rust 1.80 and higher:
```
warning: unexpected `cfg` condition name: `frb_expand`
 --> src/api/init.rs:1:1
  |
1 | #[flutter_rust_bridge::frb(init)]
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: using a cfg inside a attribute macro will use the cfgs from the destination crate and not the ones from the defining crate
  = help: try referring to `flutter_rust_bridge::frb` crate for guidance on how handle this unexpected cfg
  = help: the attribute macro `flutter_rust_bridge::frb` may come from an old version of the `flutter_rust_bridge_macros` crate, try updating your dependency with `cargo update -p flutter_rust_bridge_macros`
  = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
  = note: this warning originates in the attribute macro `flutter_rust_bridge::frb` (in Nightly builds, run with -Z macro-backtrace for more info)
```

The reason is explained in [this `flutter_rust_bridge` issue](https://github.com/fzyzcjy/flutter_rust_bridge/issues/2425) and also in [this official Rust Blog](https://blog.rust-lang.org/2024/05/06/check-cfg.html) post.

I went with the general recommendation and added the section below to the `Cargo.toml` file:
```toml
[lints.rust]
unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)'] }
```