### PR TITLE
fix: building for flutter `3.32.0`

### DIFF
--- a/rhttp/cargokit/gradle/plugin.gradle
+++ b/rhttp/cargokit/gradle/plugin.gradle
@@ -95,7 +95,7 @@ class CargoKitPlugin implements Plugin<Project> {
    private Plugin _findFlutterPlugin(Map projects) {
         for (project in projects) {
             for (plugin in project.value.getPlugins()) {
-                if (plugin.class.name == "FlutterPlugin") {
+                if (plugin.class.name == "com.flutter.gradle.FlutterPlugin") {
                     return plugin;
                 }
             }
@@ -132,7 +132,7 @@ class CargoKitPlugin implements Plugin<Project> {
             def jniLibs = project.android.sourceSets.maybeCreate(buildType).jniLibs;
             jniLibs.srcDir(new File(cargoOutputDir))
 
-            def platforms = plugin.getTargetPlatforms().collect()
+            def platforms = com.flutter.gradle.FlutterPluginUtils.getTargetPlatforms(project).collect()
 
             // Same thing addFlutterDependencies does in flutter.gradle
             if (buildType == "debug") {


### PR DESCRIPTION
after upgrading flutter from `3.29.3` to `3.32.0`, `librhttp.so` is no longer included in the apk

according to https://github.com/fzyzcjy/flutter_rust_bridge/issues/2739 & https://github.com/irondash/cargokit/issues/93#issuecomment-2847494058 the fix is easily done in `cargokit/gradle/plugin.gradle`


steps to test

1. upgrade to flutter `3.32.0`
2. use fork as dependency
  ```
  rhttp:
    git: 
      url: https://github.com/MSOB7YY/rhttp
      path: rhttp
  ```
3. run `flutter build apk --target-platform android-arm64 --release`
4. apk should have `librhttp.so` now

#### ⚠️ this might break older flutter versions, hence a major version bump is probably necessary